### PR TITLE
Update KerbalFoundries/KSPWheel versioning to support KSP 1.12

### DIFF
--- a/GameData/KSPWheel/KSPWheel.version
+++ b/GameData/KSPWheel/KSPWheel.version
@@ -25,7 +25,7 @@
 	"KSP_VERSION_MAX":
 	{
 		"MAJOR":1,
-		"MINOR":8,
-		"PATCH":9
+		"MINOR":12,
+		"PATCH":99
 	}
 }

--- a/GameData/KerbalFoundries/KerbalFoundries.version
+++ b/GameData/KerbalFoundries/KerbalFoundries.version
@@ -25,7 +25,7 @@
 	"KSP_VERSION_MAX":
 	{
 		"MAJOR":1,
-		"MINOR":8,
-		"PATCH":9
+		"MINOR":12,
+		"PATCH":99
 	}
 }


### PR DESCRIPTION
I've left the embedded TU alone since the TU on the TU repo is newer (and already has a PR). I'm not sure how you're handling embedded mods here, they seem to just be files rather than git submodules?